### PR TITLE
:sparkles: tagListの入力を受けとれるようにする #11

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -10,8 +10,9 @@ class ArticlesController < ApplicationController
 
   def create
     @user = User.find_by(id: @user_id)
-    @article = @user.articles.new(article_params)
-    @article.set_slug
+    @article = @user.articles.build(article_params)
+    @article.set_tags(params[:article][:tagList])
+
     if @article.save
       render status: :created, json: @article.to_json
     else
@@ -22,7 +23,6 @@ class ArticlesController < ApplicationController
   def update
     @article = Article.find_by(slug: params[:slug])
     if @article.update(article_params)
-      @article.set_slug
       render status: :created, json: @article.to_json
     else
       render status: :unprocessable_entity, json: @article.errors

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,22 +1,31 @@
 class Article < ApplicationRecord
   belongs_to :user
+  has_many :article_tags, dependent: :destroy
+  has_many :tags, through: :article_tags
+
+  before_save { self.slug = title.tr(" ", "-") }
+  before_update { self.slug = title.tr(" ", "-") }
 
   validates :title, presence: true
-  validates :slug, presence: true
   validates :description, presence: true
   validates :body, presence: true
   validates :user_id, presence: true
 
-  def set_slug
-    self.slug = title.tr(" ", "-")
+  def set_tags(tagList)
+    tagList.each do |name|
+      if (tag = Tag.find_by(name: name))
+      elsif (tag = Tag.new(name: name))
+      end
+      self.tags << tag
+    end
   end
 
-  def to_json(tagList = [])
+  def to_json()
     { article: { slug: slug,
                  title: title,
                  description: description,
                  body: body,
-                 tagList: tagList,
+                 tagList: tags.map(&:name),
                  createdAt: created_at,
                  updatedAt: updated_at,
                  favorited: favorited,

--- a/app/models/article_tag.rb
+++ b/app/models/article_tag.rb
@@ -1,0 +1,4 @@
+class ArticleTag < ApplicationRecord
+  belongs_to :article
+  belongs_to :tag
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,6 @@
+class Tag < ApplicationRecord
+  has_many :article_tags, dependent: :destroy
+  has_many :artices, through: :article_tags
+
+  validates :name, uniqueness: true
+end

--- a/db/migrate/20231227050716_create_tags.rb
+++ b/db/migrate/20231227050716_create_tags.rb
@@ -1,0 +1,9 @@
+class CreateTags < ActiveRecord::Migration[7.0]
+  def change
+    create_table :tags do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231227050744_create_article_tags.rb
+++ b/db/migrate/20231227050744_create_article_tags.rb
@@ -1,0 +1,10 @@
+class CreateArticleTags < ActiveRecord::Migration[7.0]
+  def change
+    create_table :article_tags do |t|
+      t.references :article, null: false, foreign_key: true
+      t.references :tag, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_26_115528) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_27_050744) do
+  create_table "article_tags", force: :cascade do |t|
+    t.integer "article_id", null: false
+    t.integer "tag_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["article_id"], name: "index_article_tags_on_article_id"
+    t.index ["tag_id"], name: "index_article_tags_on_tag_id"
+  end
+
   create_table "articles", force: :cascade do |t|
     t.string "title"
     t.string "slug"
@@ -24,6 +33,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_26_115528) do
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 
+  create_table "tags", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "username"
     t.string "email"
@@ -35,5 +50,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_26_115528) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "article_tags", "articles"
+  add_foreign_key "article_tags", "tags"
   add_foreign_key "articles", "users"
 end

--- a/test/fixtures/article_tags.yml
+++ b/test/fixtures/article_tags.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test/models/article_tag_test.rb
+++ b/test/models/article_tag_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ArticleTagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 実施タスク
tagListの入力を受け取れるようにする #11

## 実施内容
- Tagモデルの作成
- ArticleTagモデルの作成
- createの際にArticleとTagを対応づけるset_tagsメソッドを追加
- to_jsonメソッドでtagListは対応したtagから配列形式に変換することで実装
- set_slugメソッドを廃止し、before_saveとbefore_updateの際にslugをtitleから生成するように変更
  - その都合上、slugにpresence: trueを設定していると機能しなかったので削除

## その他 / 備考
なし