### PR TITLE
:sparkles: Article一覧の取得を実装 & serializerを使ってArticleの出力をリファクタリング

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,9 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby "3.2.2"
 
+# serializers
+gem "active_model_serializers"
+
 # Json Web Token for Authorization
 gem "jwt"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_model_serializers (0.10.14)
+      actionpack (>= 4.1)
+      activemodel (>= 4.1)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (7.0.8)
       activesupport (= 7.0.8)
       globalid (>= 0.3.6)
@@ -83,6 +88,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    case_transform (0.2)
+      activesupport
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
@@ -90,7 +97,6 @@ GEM
     debug (1.9.1)
       irb (~> 1.10)
       reline (>= 0.3.8)
-    diff-lcs (1.5.0)
     erubi (1.12.0)
     faker (3.2.2)
       i18n (>= 1.8.11, < 2)
@@ -118,6 +124,7 @@ GEM
       rdoc
       reline (>= 0.3.8)
     json (2.7.1)
+    jsonapi-renderer (0.2.2)
     jwt (2.7.1)
     language_server-protocol (3.17.0.3)
     listen (3.8.0)
@@ -220,19 +227,6 @@ GEM
     reline (0.4.1)
       io-console (~> 0.5)
     rexml (3.2.6)
-    rspec (3.12.0)
-      rspec-core (~> 3.12.0)
-      rspec-expectations (~> 3.12.0)
-      rspec-mocks (~> 3.12.0)
-    rspec-core (3.12.2)
-      rspec-support (~> 3.12.0)
-    rspec-expectations (3.12.3)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.6)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.12.0)
-    rspec-support (3.12.1)
     rubocop (1.59.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -291,6 +285,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  active_model_serializers
   bcrypt (~> 3.1.7)
   bootsnap
   capybara (= 3.38.0)
@@ -305,7 +300,6 @@ DEPENDENCIES
   rack-cors
   rails (~> 7.0.8)
   rails-controller-testing (= 1.0.5)
-  rspec
   rubocop
   rubocop-md
   rubocop-minitest

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,9 +1,17 @@
 class ArticlesController < ApplicationController
   before_action :authorized, only: %i[create update delete]
 
+  def index
+    @articles = Article.all
+    render status: :ok, json: { 
+      articles: ActiveModel::Serializer::CollectionSerializer.new(@articles, serializer: ArticleSerializer), 
+      articlesCount: @articles.size
+    }
+  end
+
   def show
     @article = Article.find_by(slug: params[:slug])
-    render status: :ok, json: @article.to_json
+    render status: :ok, json: @article, serializer: ArticleSerializer, root: "article", adapter: :json
   end
 
   def create
@@ -12,7 +20,7 @@ class ArticlesController < ApplicationController
     @article.set_tags(params[:article][:tagList])
 
     if @article.save
-      render status: :created, json: @article.to_json
+      render status: :created, json: @article, serializer: ArticleSerializer, root: "article", adapter: :json
     else
       render stauts: :unprocessable_entity, json: @article.errors
     end
@@ -21,7 +29,7 @@ class ArticlesController < ApplicationController
   def update
     @article = Article.find_by(slug: params[:slug])
     if @article.update(article_params)
-      render status: :created, json: @article.to_json
+      render status: :created, json: @article, serializer: ArticleSerializer, root: "article", adapter: :json
     else
       render status: :unprocessable_entity, json: @article.errors
     end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -20,19 +20,4 @@ class Article < ApplicationRecord
       self.tags << tag
     end
   end
-
-  def to_json
-    { article: { slug: slug,
-                 title: title,
-                 description: description,
-                 body: body,
-                 tagList: tags.map(&:name),
-                 createdAt: created_at,
-                 updatedAt: updated_at,
-                 favorited: favorited,
-                 favoritesCount: favoritesCount,
-                 author: { username: user.username,
-                           bio: user.bio,
-                           image: user.image } } } # followingは一旦後回し
-  end
 end

--- a/app/serializers/article_serializer.rb
+++ b/app/serializers/article_serializer.rb
@@ -1,0 +1,17 @@
+class ArticleSerializer < ActiveModel::Serializer
+  attributes %i[slug title description body tagList createdAt updatedAt favorited favoritesCount]
+
+  has_one :user, key: :author, serializer: AuthorSerializer
+
+  def tagList
+    object.tags.map(&:name)
+  end
+
+  def createdAt
+    object.created_at
+  end
+
+  def updatedAt
+    object.updated_at
+  end
+end

--- a/app/serializers/author_serializer.rb
+++ b/app/serializers/author_serializer.rb
@@ -1,0 +1,3 @@
+class AuthorSerializer < ActiveModel::Serializer
+  attributes %i[username bio image]
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
     get "/user", to: "users#show"
     put "/user", to: "users#update"
     resources :users, only: %i[create]
-    resources :articles, param: :slug, only: %i[show create update destroy]
+    resources :articles, param: :slug, only: %i[index show create update destroy]
     resources :tags, only: %i[index]
     resources :profiles, param: :username, only: %i[show] do
       member do

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -1,4 +1,19 @@
 require "test_helper"
 
 class ArticlesControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = users(:sakana)
+    @article = articles(:dragon)
+    @tagList = ["dragon", "train"]
+  end
+
+  test "get single article" do
+    @article.set_tags(@tagList)
+    get article_path(@article.slug), headers: { "Authorization": "Token #{encode({ user_id: @user.id })}" }
+  end
+
+  test "get multiple articles" do
+    @article.set_tags(@tagList)
+    get articles_path, headers: { "Authorization": "Token #{encode({ user_id: @user.id })}" }
+  end
 end

--- a/test/fixtures/articles.yml
+++ b/test/fixtures/articles.yml
@@ -7,3 +7,13 @@ dragon:
   favoritesCount: 0
   created_at: <%= 10.minutes.ago %>
   user: sakana
+
+dog:
+  title: "how to train dog"
+  slug: "how-to-train-dog"
+  description: "easy"
+  body: "fast and fast"
+  favorited: false
+  favoritesCount: 0
+  created_at: <%= 20.minutes.ago %>
+  user: sakana


### PR DESCRIPTION
## 実施タスク
Article一覧の取得を実装 #17 
serializerを使ってArticleの出力をリファクタリング #34 

## 実施内容
- active_model_serializers gemを追加
- article modelのto_jsonメソッドを削除
- ArticleSerializerとその中で使うAuthorSerializerを作成
- コントローラ内のarticleのjson出力に関数箇所をserializerでリファクタリング
- articlesコントローラのindexアクションを作成

## その他 / 備考
なし