### PR TITLE
:sparkles: タグ絞り込み機能を追加 #29

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -3,6 +3,8 @@ class ArticlesController < ApplicationController
 
   def index
     @articles = Article.all
+    @articles = Article.joins(:tags).where(tags: {name: "#{params[:tag]}"}) unless params[:tag].nil?
+
     render status: :ok, json: { 
       articles: ActiveModel::Serializer::CollectionSerializer.new(@articles, serializer: ArticleSerializer), 
       articlesCount: @articles.size

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -3,6 +3,8 @@ class Article < ApplicationRecord
   has_many :article_tags, dependent: :destroy
   has_many :tags, through: :article_tags
 
+  default_scope -> { order(created_at: :desc) }  
+
   before_save { self.slug = title.tr(" ", "-") }
   before_update { self.slug = title.tr(" ", "-") }
 


### PR DESCRIPTION
## 実施タスク
タグ絞り込み機能を追加 #29

## 実施内容
- Articlesのデフォルトの並び替え順を日付の新しい順に変更
- タグの絞りこみ機能を追加

## その他 / 備考
今はコントローラに直接絞り込み機能の中身を書いているが、後でまとめてメソッドに移す
postman.collectionのテストでtagListの順番が入れ替わるのはよくわからないので、一旦放置