### PR TITLE
:sparkles: 著者絞り込み機能の実装 #30

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -2,8 +2,16 @@ class ArticlesController < ApplicationController
   before_action :authorized, only: %i[create update delete]
 
   def index
-    @articles = Article.all
-    @articles = Article.joins(:tags).where(tags: {name: "#{params[:tag]}"}) unless params[:tag].nil?
+    # 存在しない項目には、ワイルドカードを代入
+    author = params[:author] || "%"
+    tag = params[:tag] || "%"
+
+    # すべてのテーブルをjoinして、絞り込みを行った結果のid
+    ids = Article.joins(:user, :tags).where("users.username LIKE ?", "#{author}")
+                                     .where("tags.name LIKE ?", "#{tag}")
+                                     .distinct.pluck(:id)
+
+    @articles = Article.where(id: ids)
 
     render status: :ok, json: { 
       articles: ActiveModel::Serializer::CollectionSerializer.new(@articles, serializer: ArticleSerializer), 


### PR DESCRIPTION
## 実施タスク
著者絞り込み機能の実装 #30

## 実施内容
- articlesのテーブルにusersとtagsのテーブルをjoinしてから絞りこみを行い、重複したidを削除したものを取得
- そのidでarticlesテーブルから該当するarticleを取得するように変更

## その他 / 備考
なし