### PR TITLE
:green_heart: Get Current Userのテスト fixes #47

### DIFF
--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,4 +1,17 @@
 require "test_helper"
 
 class UsersControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = users(:sakana)
+  end
+
+  test "authorizedなときにshowアクションにアクセスできる" do
+    get user_path, headers: header_token(@user)
+    assert_response :ok
+  end
+
+  test "authorizedでないときにshowアクションにアクセスできない" do
+    get user_path
+    assert_response :unauthorized
+  end  
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,4 +13,7 @@ class ActiveSupport::TestCase
   fixtures :all
 
   # Add more helper methods to be used by all tests here...
+  def header_token(user)
+    { "Authorization": "Token #{ encode({ user_id: user.id })}" }
+  end
 end


### PR DESCRIPTION
## 実施タスク
Get Current Userのテスト #47

## 実施内容
- invalidな情報でcurrent userを取得できない
- validな情報でcurrent userを取得できる
- test helperに認証用のheader_tokenメソッドを追加

## その他 / 備考
なし