### PR TITLE
:green_heart: Update Userのテスト fixes #48

### DIFF
--- a/test/integration/users_update_test.rb
+++ b/test/integration/users_update_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+class UsersUpdateTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = users(:sakana)
+  end
+
+  test "ログインしないとupdateできない" do
+    put user_path, params: { user: { username: "neo sakana", 
+                                     email: "neo.sakana@example.com", 
+                                     password: "qassword", 
+                                     image: "https://i.stack.imgur.com/xHWG8.jpg", 
+                                     bio: "I'm fish. " } }
+    assert_response :unauthorized
+  end
+
+  test "invalidな情報でupdateが失敗する" do
+    put user_path, headers: header_token(@user), params: { user: { username: "", 
+                                                 email: "", 
+                                                 password: "", 
+                                                 image: "", 
+                                                 bio: "" } }
+    assert_response :unprocessable_entity
+  end
+
+  test "validな情報でupdateが成功する" do
+    put user_path, headers: header_token(@user), params: { user: { username: "neo sakana", 
+                                                 email: "neo.sakana@example.com", 
+                                                 password: "qassword", 
+                                                 image: "https://i.stack.imgur.com/xHWG8.jpg", 
+                                                 bio: "I'm fish. " } }
+    assert_response :created
+  end
+end


### PR DESCRIPTION
## 実施タスク
Update Userのテスト fixes #48

## 実施内容
- 認証なしでユーザー情報をupdateできない
- invalidな情報でユーザー情報をupdateできない
- validな情報でユーザー情報をupdateできる

## その他 / 備考
なし