### PR TITLE
:green_heart: Get Profileのテスト fixes #49

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,6 +1,6 @@
 class ProfilesController < ApplicationController
   before_action :certificated, only: %i[show follow unfollow]
-  before_action :authorized, only: %i[show follow unfollow]
+  before_action :authorized, only: %i[follow unfollow]
 
   def show
     @current_user = User.find_by(id: @user_id)

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -1,7 +1,18 @@
 require "test_helper"
 
 class ProfilesControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  def setup
+    @current_user = users(:sakana)
+    @some_user = users(:fish)
+  end
+
+  test "認証なしでprofileを取得できる" do
+    get profile_path(@some_user.username)
+    assert_response :ok
+  end
+
+  test "認証ありでprofileを取得できる" do
+    get profile_path(@some_user.username), headers: header_token(@current_user)
+    assert_response :ok
+  end
 end


### PR DESCRIPTION
## 実施タスク
Get Profileのテスト fixes #49

## 実施内容
- 認証なしでProfileを取得できる
- 認証ありでProfileを取得できる
- Profileの取得に認可が必要になっていたので、修正

## その他 / 備考
なし