### PR TITLE
:green_heart: Delete Articleのテスト fixes #57

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,6 +1,6 @@
 class ArticlesController < ApplicationController
-  before_action :certificated, only: %i[create update delete]
-  before_action :authorized, only: %i[create update delete]
+  before_action :certificated, only: %i[create update destroy]
+  before_action :authorized, only: %i[create update destroy]
 
   def index
     # 存在しない項目には、ワイルドカードを代入
@@ -49,7 +49,7 @@ class ArticlesController < ApplicationController
 
   def destroy
     Article.find_by(slug: params[:slug]).delete
-    render status: :ok
+    render status: :no_content
   end
 
   private

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -23,6 +23,6 @@ class CommentsController < ApplicationController
 
   def destroy
     Comment.find_by(id: params[:id]).delete
-    render status: :ok
+    render status: :no_content
   end
 end

--- a/test/integration/articles_delete_test.rb
+++ b/test/integration/articles_delete_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class ArticlesDeleteTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = users(:sakana)
+    @article = articles(:dragon)
+  end
+
+  test "認証なしでdeleteできない" do
+    delete article_path(@article.slug)
+    assert_response :unauthorized
+  end
+  
+  test "認証ありでdeleteできる" do
+    delete article_path(@article.slug), headers: header_token(@user)
+    assert_response :no_content
+  end
+end


### PR DESCRIPTION
## 実施タスク
Delete Articleのテスト fixes #57

## 実施内容
- 認証なしでdeleteできない
- 認証ありでdeleteできる
- Articlesコントローラのbefore_actionにdeleteで指定していたので、destroyに修正
- Articles, Commentsコントローラのdestroyアクションのres codeを:okから:no_contentに変更

## その他 / 備考
なし