### PR TITLE
:green_heart: お気に入りの実装 fixes #33

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,6 +1,6 @@
 class ArticlesController < ApplicationController
-  before_action :certificated, only: %i[create update destroy]
-  before_action :authorized, only: %i[create update destroy]
+  before_action :certificated, only: %i[create update destroy favorite unfavorite]
+  before_action :authorized, only: %i[create update destroy favorite unfavorite]
 
   def index
     # 存在しない項目には、ワイルドカードを代入
@@ -52,8 +52,22 @@ class ArticlesController < ApplicationController
     render status: :no_content
   end
 
+  def favorite
+    @user = User.find_by(id: @user_id)
+    @article = Article.find_by(slug: params[:slug])
+    @user.favorite(@article)
+    render status: :created, json: @article, serializer: ArticleSerializer, root: "article", adapter: :json, current_user: @user
+  end
+
+  def unfavorite
+    @user = User.find_by(id: @user_id)
+    @article = Article.find_by(slug: params[:slug])
+    @user.unfavorite(@article)
+    render status: :ok, json: @article, serializer: ArticleSerializer, root: "article", adapter: :json, current_user: @user
+  end
+
   private
     def article_params
-      params.require(:article).permit(:title, :description, :body, :favorited, :favoritesCount)
+      params.require(:article).permit(:title, :description, :body)
     end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -3,6 +3,8 @@ class Article < ApplicationRecord
   has_many :article_tags, dependent: :destroy
   has_many :tags, through: :article_tags
   has_many :comments, dependent: :destroy
+  has_many :favorites, dependent: :destroy
+  has_many :fav_users, through: :favorites, source: :user
 
   default_scope -> { order(created_at: :desc) }  
 
@@ -22,5 +24,9 @@ class Article < ApplicationRecord
       end
       self.tags << tag
     end
+  end
+
+  def favorited?(user)
+    fav_users.include?(user)
   end
 end

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,0 +1,6 @@
+class Favorite < ApplicationRecord
+  belongs_to :article
+  belongs_to :user
+  validates :article_id, presence: true
+  validates :user_id, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,8 @@ class User < ApplicationRecord
   has_many :following, through: :active_relationships, source: :followed
   has_many :followers, through: :passive_relationships, source: :follower
   has_many :comments
+  has_many :favorites, dependent: :destroy
+  has_many :fav_articles, through: :favorites, source: :article
 
   validates :email, presence: true
   validates :username, presence: true
@@ -31,5 +33,18 @@ class User < ApplicationRecord
 
   def following?(other_user)
     following.include?(other_user)
+  end
+
+  # favorite関係のメソッド
+  def favorite(article)
+    fav_articles << article
+  end
+
+  def unfavorite(article)
+    fav_articles.delete(article)
+  end
+
+  def favorite?(article)
+    fav_articles.include?(article)
   end
 end

--- a/app/serializers/article_serializer.rb
+++ b/app/serializers/article_serializer.rb
@@ -6,6 +6,7 @@ class ArticleSerializer < ActiveModel::Serializer
   def initialize(object, options = {})
     super(object, options)
     @tagFilterName = options[:tagFilterName]
+    @current_user = options[:current_user]
   end
 
   def tagList
@@ -23,5 +24,13 @@ class ArticleSerializer < ActiveModel::Serializer
 
   def updatedAt
     object.updated_at
+  end
+
+  def favorited
+    object.favorited?(@current_user)
+  end
+
+  def favoritesCount
+    object.fav_users.count
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,13 +7,15 @@ Rails.application.routes.draw do
     resources :articles, param: :slug, only: %i[index show create update destroy] do
       member do
         resources :comments, only: %i[index create destroy]
+        post :favorite, to: "articles#favorite"
+        delete :favorite, to: "articles#unfavorite"
       end
     end
     resources :tags, only: %i[index]
     resources :profiles, param: :username, only: %i[show] do
       member do
-        post :follow, to: 'profiles#follow'
-        delete :follow, to: 'profiles#unfollow'
+        post :follow, to: "profiles#follow"
+        delete :follow, to: "profiles#unfollow"
       end
     end
   end

--- a/db/migrate/20231226115528_create_articles.rb
+++ b/db/migrate/20231226115528_create_articles.rb
@@ -5,8 +5,6 @@ class CreateArticles < ActiveRecord::Migration[7.0]
       t.string :slug
       t.string :description
       t.text :body
-      t.boolean :favorited, default: false, null: false
-      t.integer :favoritesCount, default: 0
       t.references :user, null: false, foreign_key: true
 
       t.timestamps

--- a/db/migrate/20231230115141_create_favorites.rb
+++ b/db/migrate/20231230115141_create_favorites.rb
@@ -1,0 +1,11 @@
+class CreateFavorites < ActiveRecord::Migration[7.0]
+  def change
+    create_table :favorites do |t|
+      t.references :article, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :favorites, [:article_id, :user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_30_044624) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_30_115141) do
   create_table "article_tags", force: :cascade do |t|
     t.integer "article_id", null: false
     t.integer "tag_id", null: false
@@ -25,8 +25,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_30_044624) do
     t.string "slug"
     t.string "description"
     t.text "body"
-    t.boolean "favorited", default: false, null: false
-    t.integer "favoritesCount", default: 0
     t.integer "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -41,6 +39,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_30_044624) do
     t.datetime "updated_at", null: false
     t.index ["article_id"], name: "index_comments_on_article_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
+  create_table "favorites", force: :cascade do |t|
+    t.integer "article_id", null: false
+    t.integer "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["article_id", "user_id"], name: "index_favorites_on_article_id_and_user_id", unique: true
+    t.index ["article_id"], name: "index_favorites_on_article_id"
+    t.index ["user_id"], name: "index_favorites_on_user_id"
   end
 
   create_table "relationships", force: :cascade do |t|
@@ -75,4 +83,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_30_044624) do
   add_foreign_key "articles", "users"
   add_foreign_key "comments", "articles"
   add_foreign_key "comments", "users"
+  add_foreign_key "favorites", "articles"
+  add_foreign_key "favorites", "users"
 end

--- a/test/fixtures/articles.yml
+++ b/test/fixtures/articles.yml
@@ -3,8 +3,6 @@ dragon:
   slug: "how-to-train-dragon"
   description: "carefully"
   body: "slow and slow"
-  favorited: false
-  favoritesCount: 0
   created_at: <%= 10.minutes.ago %>
   user: sakana
 
@@ -13,7 +11,5 @@ dog:
   slug: "how-to-train-dog"
   description: "easy"
   body: "fast and fast"
-  favorited: false
-  favoritesCount: 0
   created_at: <%= 20.minutes.ago %>
   user: sakana

--- a/test/integration/users_favorite_test.rb
+++ b/test/integration/users_favorite_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class UsersFavoriteTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = users(:sakana)
+    @article = articles(:dragon)
+  end
+
+  test "認可なしでfavoriteできない" do
+    assert_no_difference "@article.fav_users.count" do
+      post favorite_article_path(@article.slug)
+    end
+    assert_response :unauthorized
+  end
+
+  test "認可なしでunfavoriteできない" do
+    @user.favorite(@article)
+    assert_no_difference "@article.fav_users.count" do
+      delete favorite_article_path(@article.slug)
+    end
+    assert_response :unauthorized
+  end
+
+  test "認可ありでfavoriteできる" do
+    assert_difference "@article.fav_users.count", 1 do
+      post favorite_article_path(@article.slug), headers: header_token(@user)
+    end
+    assert_response :created
+    assert_equal true, JSON.parse(response.body)["article"]["favorited"]
+  end
+
+  test "認可ありでunfavoriteできる" do
+    @user.favorite(@article)
+    assert_difference "@article.fav_users.count", -1 do
+      delete favorite_article_path(@article.slug), headers: header_token(@user)
+    end
+    assert_response :ok
+    assert_equal false, JSON.parse(response.body)["article"]["favorited"]
+  end
+end

--- a/test/models/favorite_test.rb
+++ b/test/models/favorite_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class FavoriteTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 実施タスク
お気に入りの実装 fixes #33

## 実施内容
- ArticleモデルからfavoritedとfavoritesCountを削除
- ArticleSerializerのFavoritedとFavoritesCountを計算して出すように変更
- Favoriteモデルを作成して、UserモデルとArticleモデルを結び付け
- UserモデルとArticleモデルにfavorite関連メソッドを定義
- 余計なFavoriteのfixturesを削除
- favorite test

## その他 / 備考
favoriteに関するmodel側のテストはまだ