### PR TITLE
:memo: コメント修正 fixes #80

### DIFF
--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -5,13 +5,13 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     @user = users(:sakana)
   end
 
-  test "authorizedなときにshowアクションにアクセスできる" do
-    get user_path, headers: header_token(@user)
-    assert_response :ok
-  end
-
-  test "authorizedでないときにshowアクションにアクセスできない" do
+  test "認証なしでshowアクションにアクセスできない" do
     get user_path
     assert_response :unauthorized
   end  
+
+  test "認証ありでshowアクションにアクセスできる" do
+    get user_path, headers: header_token(@user)
+    assert_response :ok
+  end
 end

--- a/test/integration/articles_delete_test.rb
+++ b/test/integration/articles_delete_test.rb
@@ -6,12 +6,12 @@ class ArticlesDeleteTest < ActionDispatch::IntegrationTest
     @article = articles(:dragon)
   end
 
-  test "認証なしでdeleteできない" do
+  test "認可なしでdeleteできない" do
     delete article_path(@article.slug)
     assert_response :unauthorized
   end
   
-  test "認証ありでdeleteできる" do
+  test "認可ありでdeleteできる" do
     delete article_path(@article.slug), headers: header_token(@user)
     assert_response :no_content
   end

--- a/test/integration/articles_post_test.rb
+++ b/test/integration/articles_post_test.rb
@@ -5,7 +5,7 @@ class ArticlesPostTest < ActionDispatch::IntegrationTest
     @user = users(:sakana)
   end
 
-  test "認証なしでpostできない" do
+  test "認可なしでpostできない" do
     assert_no_difference "Article.count" do
       post articles_path, params: { article: { title: "title example",
                                                description: "description example",

--- a/test/integration/articles_update_test.rb
+++ b/test/integration/articles_update_test.rb
@@ -6,7 +6,7 @@ class ArticlesUpdateTest < ActionDispatch::IntegrationTest
     @article = articles(:dragon)
   end
 
-  test "認証なしでupdateできない" do
+  test "認可なしでupdateできない" do
     put article_path(@article.slug), params: { article: { title: "neo dragon", 
                                                           description: "neo description", 
                                                           body: "neo body" } }

--- a/test/integration/users_follow_test.rb
+++ b/test/integration/users_follow_test.rb
@@ -6,13 +6,13 @@ class UsersFollowTest < ActionDispatch::IntegrationTest
     @some_user = users(:fish)
   end
 
-  test "認証なしでfollowできない" do
+  test "認可なしでfollowできない" do
     post follow_profile_path(@some_user.username)
     assert_response :unauthorized
     assert_not @current_user.reload.following?(@some_user)
   end
 
-  test "認証なしでunfollowできない" do
+  test "認可なしでunfollowできない" do
     post follow_profile_path(@some_user.username), headers: header_token(@current_user)
     delete follow_profile_path(@some_user.reload.username)
     assert_response :unauthorized


### PR DESCRIPTION
## 実施タスク
コメント修正 fixes #80

## 実施内容
- 一部の「認証なしで」を「認可なしで」に修正

## その他 / 備考
なし