### PR TITLE
:green_heart: Delete Commentのテスト fixes #60

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,4 +17,9 @@ class ApplicationController < ActionController::API
       render status: :unauthorized, json: { error: "Unauthorized" }
     end
   end
+
+  # ログインユーザーと記事/コメントを書いた人物が同じかを確かめる
+  def correct_user(letter)
+    render status: :forbidden, json: { error: "Forbidden" } unless @current_user == letter.user
+  end
 end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -48,7 +48,10 @@ class ArticlesController < ApplicationController
   end
 
   def destroy
-    Article.find_by(slug: params[:slug]).delete
+    @article = Article.find_by(slug: params[:slug])
+    @current_user = User.find_by(id: @user_id)
+    correct_user(@article) and return
+    @article.destroy
     render status: :no_content
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,6 +1,6 @@
 class CommentsController < ApplicationController
-  before_action :certificated, only: %i[index create delete]
-  before_action :authorized, only: %i[create delete]
+  before_action :certificated, only: %i[index create destroy]
+  before_action :authorized, only: %i[create destroy]
 
   def index
     @article = Article.find_by(slug: params[:slug])
@@ -22,7 +22,10 @@ class CommentsController < ApplicationController
   end
 
   def destroy
-    Comment.find_by(id: params[:id]).delete
+    @comment = Comment.find_by(id: params[:id])
+    @current_user = User.find_by(id: @user_id)
+    correct_user(@comment) and return # renderしたらreturnしないとdouble renderエラーになる
+    @comment.destroy
     render status: :no_content
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ApplicationRecord
                                    dependent: :destroy
   has_many :following, through: :active_relationships, source: :followed
   has_many :followers, through: :passive_relationships, source: :follower
-  has_many :comments
+  has_many :comments, dependent: :destroy
   has_many :favorites, dependent: :destroy
   has_many :fav_articles, through: :favorites, source: :article
 

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -2,3 +2,8 @@ yellow:
   body: "This color is yellow. "
   article: dragon
   user: sakana
+
+blue:
+  body: "This color is blue. "
+  article: dragon
+  user: fish

--- a/test/integration/articles_delete_test.rb
+++ b/test/integration/articles_delete_test.rb
@@ -4,15 +4,30 @@ class ArticlesDeleteTest < ActionDispatch::IntegrationTest
   def setup
     @user = users(:sakana)
     @article = articles(:dragon)
+    @other_user_article = articles(:fox)
   end
 
-  test "認可なしでdeleteできない" do
-    delete article_path(@article.slug)
+  test "認可なしで削除できない" do
+    assert_no_difference "Article.count" do
+      delete article_path(@article.slug)
+    end
     assert_response :unauthorized
   end
   
-  test "認可ありでdeleteできる" do
-    delete article_path(@article.slug), headers: header_token(@user)
+  test "他人の記事を削除できない" do
+    assert_no_difference "Article.count" do
+      delete article_path(@other_user_article.slug), headers: header_token(@user)    
+    end
+    assert_response :forbidden
+  end
+
+  test "自分の記事を削除できる" do
+    assert_difference "Article.count", -1 do
+      delete article_path(@article.slug), headers: header_token(@user)
+    end
     assert_response :no_content
+    assert_equal 0, @article.tags.count
+    assert_equal 0, @article.comments.count
+    assert_equal 0, @article.fav_users.count
   end
 end

--- a/test/integration/comments_delete_test.rb
+++ b/test/integration/comments_delete_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+class CommentsDeleteTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = users(:sakana)
+    @article = articles(:dragon)
+    @comment = comments(:yellow)
+    @other_user_comment = comments(:blue)
+  end
+
+  test "認可なしで削除できない" do
+    assert_no_difference "@article.comments.count" do
+      delete comment_path(@article.slug, @comment.id)
+    end
+    assert_response :unauthorized
+  end
+
+  test "他人のコメントを削除できない" do
+    assert_no_difference "@article.comments.count" do
+      delete comment_path(@article.slug, @other_user_comment.id), headers: header_token(@user)
+    end
+    assert_response :forbidden
+  end
+
+  test "自分のコメントを削除できる" do
+    assert_difference "@article.comments.count", -1 do
+      delete comment_path(@article.slug, @comment.id), headers: header_token(@user)
+    end
+    assert_response :no_content
+  end
+end


### PR DESCRIPTION
## 実施タスク
Delete Commentのテスト fixes #60

## 実施内容
### Delete Comment
- test: 認可なしでコメントを削除できない
- test: 自分のコメントを削除できる
- test: 他人のコメントを削除できない
- correct_userメソッドの追加(renderしたらreturnを入れるように注意)
- Commentsコントローラでcorrect_userを読み込むように修正
- deleteで削除していたので、destroyに変更

### Delete Article
- test: 他人の記事を削除できない
- Aritlcesコントローラでcorrect_userを読み込むように修正
- deleteで削除していたので、destroyに変更

### User model
- ついでにUserが削除されたらCommentが削除されるように変更

## その他 / 備考
他人のものを削除できないようにするのをArticle側に書き忘れていたので、一緒に修正した。
commentのfixturesを追加したら、Delete Articleのテストにエラーが生じたので、修正した。