### PR TITLE
:sparkles: feedの実装 fixes #32

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,9 +1,11 @@
 class ArticlesController < ApplicationController
-  before_action :certificated, only: %i[create update destroy favorite unfavorite]
-  before_action :authorized, only: %i[create update destroy favorite unfavorite]
+  before_action :certificated, only: %i[create update destroy favorite unfavorite feed]
+  before_action :authorized, only: %i[create update destroy favorite unfavorite feed]
 
   def index
-    filter_articles
+    ids = filter_articles
+    common_filter(ids)
+
     render status: :ok, json: { 
       articles: ActiveModel::Serializer::CollectionSerializer.new(@articles, serializer: ArticleSerializer, tagFilterName: params[:tag]), 
       articlesCount: @articles.size
@@ -58,26 +60,42 @@ class ArticlesController < ApplicationController
     render status: :ok, json: @article, serializer: ArticleSerializer, root: "article", adapter: :json, current_user: @user
   end
 
+  def feed
+    @user = User.find_by(id: @user_id)
+    ids = Article.joins(:user).where("users.id IN (?)", @user.following.map(&:id)).map(&:id)
+
+    common_filter(ids)
+    render status: :ok, json: { 
+      articles: ActiveModel::Serializer::CollectionSerializer.new(@articles, serializer: ArticleSerializer), 
+      articlesCount: @articles.size
+    }
+  end
+
   private
     def article_params
       params.require(:article).permit(:title, :description, :body)
     end
 
-    def filter_articles
+    def common_filter(ids)
       limit = params[:limit] || 20
+      offset = params[:offset].to_i || 0
 
+      # オフセット
+      ids = ids.slice(offset..-1)
+
+      # ページネーション
+      @articles = Article.where(id: ids).paginate(page: params[:page], per_page: limit)
+    end
+
+    def filter_articles
       if !params[:author].nil?
         ids = Article.joins(:user).where("users.username LIKE ?", "#{params[:author]}").map(&:id)
       elsif !params[:tag].nil?
         ids = Article.joins(:tags).where("tags.name LIKE ?", "#{params[:tag]}").map(&:id)
       elsif !params[:favorited].nil?
         ids = Article.joins(:favorites).where("favorites.user_id LIKE ?", "#{User.find_by(username: params[:favorited]).id}").map(&:id)
-      elsif !params[:offset].nil?
-        ids = Article.all.slice(params[:offset].to_i..-1).map(&:id)
       else
         ids = Article.all.map(&:id)
       end
-  
-      @articles = Article.where(id: ids).paginate(page: params[:page], per_page: limit)
     end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,9 @@ Rails.application.routes.draw do
         post :favorite, to: "articles#favorite"
         delete :favorite, to: "articles#unfavorite"
       end
+      collection do
+        get :feed, to: "articles#feed"
+      end
     end
     resources :tags, only: %i[index]
     resources :profiles, param: :username, only: %i[show] do

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -19,6 +19,10 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "offset" do
-    get articles_path({offset: 2}), headers: header_token(@user)
+    get articles_path({offset: 1}), headers: header_token(@user)
+  end
+
+  test "feed" do
+    get feed_articles_path, headers: header_token(@user)
   end
 end

--- a/test/fixtures/articles.yml
+++ b/test/fixtures/articles.yml
@@ -21,3 +21,11 @@ fox:
   body: "hoge hoge"
   created_at: <%= 15.minutes.ago %>
   user: fish
+
+bear:
+  title: "how to train bear"
+  slug: "how-to-train-bear"
+  description: "fuga"
+  body: "fuga fuga"
+  created_at: <%= 15.minutes.ago %>
+  user: fish

--- a/test/fixtures/relationships.yml
+++ b/test/fixtures/relationships.yml
@@ -1,0 +1,3 @@
+relation1:
+  follower: <%= User.find_by(username: "sakana") %>
+  followed: <%= User.find_by(username: "uo") %>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -11,3 +11,10 @@ fish:
   password_digest: <%= User.digest('password') %>
   bio: null
   image: null
+
+uo:
+  username: uo
+  email: uo@example.com
+  password_digest: <%= User.digest('password') %>
+  bio: null
+  image: null

--- a/test/integration/users_follow_test.rb
+++ b/test/integration/users_follow_test.rb
@@ -19,12 +19,6 @@ class UsersFollowTest < ActionDispatch::IntegrationTest
     assert @current_user.reload.following?(@some_user)
   end
 
-  test "自分自身はfollowできない" do
-    assert_not @current_user.following?(@current_user)
-    post follow_profile_path(@current_user.username), headers: header_token(@current_user)
-    assert_not @current_user.reload.following?(@current_user)
-  end
-
   # TODO: 後でuserモデルのテストに移した方が良さそう
   test "followersとfollowingに適切に値が入る" do
     assert_equal [], @current_user.following


### PR DESCRIPTION
## 実施タスク
feedの実装 fixes #32

## 実施内容
- feedの実装
- limitとoffsetをfeedとarticleで使えるように、common_filterメソッドに分割

## その他 / 備考
なし