### PR TITLE
:green_heart: Articleモデルのテスト fixes 69

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -8,13 +8,15 @@ class Article < ApplicationRecord
 
   default_scope -> { order(created_at: :desc) }  
 
-  before_save { self.slug = title.tr(" ", "-") }
-  before_update { self.slug = title.tr(" ", "-") }
+  before_validation { self.slug = title.tr(" ", "-") }
 
   validates :title, presence: true
   validates :description, presence: true
   validates :body, presence: true
   validates :user_id, presence: true
+
+  EXCLUDE_SYMBOL_REGEX = /\A[^!\#$'()*+,\/:;=?@\[\]]+\z/
+  validates :slug, presence: true, uniqueness: true, format: { with: EXCLUDE_SYMBOL_REGEX }
 
   def set_tags(tagList)
     return tags if tagList.nil?

--- a/app/models/article_tag.rb
+++ b/app/models/article_tag.rb
@@ -1,4 +1,6 @@
 class ArticleTag < ApplicationRecord
   belongs_to :article
   belongs_to :tag
+
+  validates :article_id, uniqueness: { scope: :tag_id }
 end

--- a/db/migrate/20231227050744_create_article_tags.rb
+++ b/db/migrate/20231227050744_create_article_tags.rb
@@ -6,6 +6,6 @@ class CreateArticleTags < ActiveRecord::Migration[7.0]
 
       t.timestamps
     end
-    # add_index :article_tags, [:article, :tag], unique: true
+    add_index :article_tags, [:article_id, :tag_id], unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,6 +16,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_30_115141) do
     t.integer "tag_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["article_id", "tag_id"], name: "index_article_tags_on_article_id_and_tag_id", unique: true
     t.index ["article_id"], name: "index_article_tags_on_article_id"
     t.index ["tag_id"], name: "index_article_tags_on_tag_id"
   end

--- a/test/fixtures/articles.yml
+++ b/test/fixtures/articles.yml
@@ -29,3 +29,11 @@ bear:
   body: "fuga fuga"
   created_at: <%= 15.minutes.ago %>
   user: fish
+
+recent:
+  title: "recent"
+  slug: "recent"
+  description: "recent"
+  body: "recent"
+  created_at: <%= Time.zone.now %>
+  user: sakana

--- a/test/models/article_tag_test.rb
+++ b/test/models/article_tag_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+# require "test_helper"
 
-class ArticleTagTest < ActiveSupport::TestCase
-end
+# class ArticleTagTest < ActiveSupport::TestCase
+# end

--- a/test/models/article_test.rb
+++ b/test/models/article_test.rb
@@ -3,7 +3,8 @@ require "test_helper"
 class ArticleTest < ActiveSupport::TestCase
   def setup
     @user = users(:sakana)
-    @article = articles(:dragon)
+    @other_user = users(:fish)
+    @article = @user.articles.build(title: "title dayo", description: "description", body: "body", slug: "title-dayo")
   end
 end
 
@@ -11,9 +12,13 @@ class ArticleCommonTest < ArticleTest
   test "適切な値でarticleがvalidになる" do
     assert @article.valid?
   end
+
+  test "recentが最初にこなければinvalid" do
+    assert_equal articles(:recent), Article.first
+  end
 end
 
-class PresenceTest < ArticleTest
+class ArticlePresenceTest < ArticleTest
   test "user_idが存在しなければinvalid" do
     @article.user_id = nil
     assert_not @article.valid?
@@ -35,23 +40,52 @@ class PresenceTest < ArticleTest
   end
 end
 
-# class SlugTest < ArticleTest
-#   test "slugに特殊文字が存在したらinvalid" do
-#     invalid_symbol_array = %w[! # $ ' ( ) * + , / : ; = ? @ [ ]]
-#     invalid_symbol_array.each do |symbol|
-#       @article.slug = symbol
-#       assert_not @article.valid?
-#     end
-#   end
+class ArticleSlugTest < ArticleTest
+  test "slugに特殊文字が存在したらinvalid" do
+    invalid_symbol_array = %w[! # $ ' ( ) * + , / : ; = ? @ [ ]]
+    invalid_symbol_array.each do |symbol|
+      @article.title = "symbol" + symbol
+      assert_not @article.valid?
+    end
+  end
 
-#   test "slugが存在しなければinvalid" do
-#     @article.slug = "    "
-#     assert_not @article.valid?
-#   end
+  test "slugが存在しなければinvalid" do
+    @article.title = "    " # slugはtitleから自動生成される
+    assert_not @article.valid?
+  end
 
-#   test "slugがuniqueでなければinvalid" do
-#     @article_same_slug = @user.articles.build(content: "Lorem ipsum2", title: "title2", slug: "title-dayo")
-#     @article.save
-#     assert_not @article_same_slug.valid?
-#   end
-# end
+  test "slugがuniqueでなければinvalid" do
+    @article_same_slug = @user.articles.build(body: "Lorem ipsum2", description: "description", title: @article.title)
+    @article.save
+    assert_not @article_same_slug.valid?
+  end
+end
+
+class ArtcleCommentTest < ArticleTest
+  test "Articleを削除したらコメントも削除される" do
+    @article.save
+    @article.comments.create!(body: "comment body", user: @other_user)
+    assert_difference "Comment.count", -1 do
+      @article.destroy
+    end
+  end
+end
+
+class ArticleTagTest < ArticleTest
+  test "Articleを削除したらタグの紐づけも削除される" do
+    @article.save
+    @article.tags.create!(name: "New Tag")
+    assert_difference "ArticleTag.count", -1 do
+      @article.destroy
+    end
+  end
+
+  test "1つの記事に同じタグを複数設定できない" do
+    @article.save
+    @tag = Tag.new(name: "New Tag")
+    @articletag1 = ArticleTag.new(article_id: @article.id, tag_id: @tag.id)
+    @articletag1.save
+    @articletag2 = ArticleTag.new(article_id: @article.id, tag_id: @tag.id)
+    assert_not @articletag2.valid?
+  end
+end

--- a/test/models/favorite_test.rb
+++ b/test/models/favorite_test.rb
@@ -1,7 +1,7 @@
-require "test_helper"
+# require "test_helper"
 
-class FavoriteTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
-end
+# class FavoriteTest < ActiveSupport::TestCase
+#   # test "the truth" do
+#   #   assert true
+#   # end
+# end

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+# require "test_helper"
 
-class RelationshipTest < ActiveSupport::TestCase
-end
+# class RelationshipTest < ActiveSupport::TestCase
+# end


### PR DESCRIPTION
## 実施タスク
Articleモデルのテスト fixes 69

## 実施内容
### test
- usre_id, title, description, bodyのpresence
- articleが削除されたときにcommentとarticle_tagも一緒に削除される
- 1つの記事に同じタグを複数設定できない
- slugのvalidation

### それ以外の変更
- ArticleTagのappとdbでのunique設定
- slugをbefore_save, before_updateからbefore_validationへ変更

## その他 / 備考
なし