### PR TITLE
:green_heart: Userモデルのテスト fixes #68

### DIFF
--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -3,4 +3,5 @@ class Relationship < ApplicationRecord
   belongs_to :followed, class_name: "User"
   validates :follower_id, presence: true
   validates :followed_id, presence: true
+  validates :follower_id, uniqueness: { scope: :followed_id }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,9 +12,20 @@ class User < ApplicationRecord
   has_many :favorites, dependent: :destroy
   has_many :fav_articles, through: :favorites, source: :article
 
-  validates :email, presence: true
-  validates :username, presence: true
+  before_save { email.downcase! }
+
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d-]+(\.[a-z\d-]+)*\.[a-z]+\z/i
+  validates :email, presence: true, length: { maximum: 255 },
+                    format: { with: VALID_EMAIL_REGEX },
+                    uniqueness: true
+
+  VALID_USERNAME_REGEX = /\A[^.]+\z/
+  validates :username, presence: true,
+                      length: { maximum: 50 },
+                      format: { with: VALID_USERNAME_REGEX },
+                      uniqueness: true
   has_secure_password
+  validates :password, presence: true, length: { minimum: 6 }
 
   def self.digest(string)
     cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST :

--- a/test/integration/users_follow_test.rb
+++ b/test/integration/users_follow_test.rb
@@ -19,26 +19,6 @@ class UsersFollowTest < ActionDispatch::IntegrationTest
     assert @current_user.reload.following?(@some_user)
   end
 
-  # TODO: 後でuserモデルのテストに移した方が良さそう
-  test "followersとfollowingに適切に値が入る" do
-    assert_equal [], @current_user.following
-    assert_equal [], @some_user.followers
-    post follow_profile_path(@some_user.username), headers: header_token(@current_user)
-    assert_equal [@some_user], @current_user.reload.following
-    assert_equal [@current_user], @some_user.reload.followers
-    delete follow_profile_path(@some_user.username), headers: header_token(@current_user)
-    assert_equal [], @current_user.reload.following
-    assert_equal [], @some_user.reload.followers
-  end
-
-  # テストすると、sqliteのUNIQUE constraintでエラー吐くから多分ok
-  # test "2回followしても、余計な中間テーブルが生まれない" do
-  #   assert_difference "@current_user.following.size", 1 do
-  #     post follow_profile_path(@some_user.username), headers: header_token(@current_user)
-  #     post follow_profile_path(@some_user.username), headers: header_token(@current_user)
-  #   end
-  # end
-
   test "validな情報でfollowとunfollowできる" do
     assert_not @current_user.following?(@some_user)
     post follow_profile_path(@some_user.username), headers: header_token(@current_user)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class UserTest < ActiveSupport::TestCase
   def setup
-    @user = users(:sakana)
+    @user = User.new(username: "Example User", email: "hoge@example.com", password: "password", password_confirmation: "password")
   end
 end
 
@@ -10,14 +10,6 @@ class UserCommonTest < UserTest
   test "適切な値でuserがvalidになる" do
     assert @user.valid?
   end
-
-  # test "userをdestroyすると、articleもdestroyされる" do
-  #   @user.save
-  #   @user.articles.create!(content: "Lorem ipsum", title: "title", slug: "slug")
-  #   assert_difference "Article.count", -1 do
-  #     @user.destroy
-  #   end
-  # end
 end
 
 class UserNameTest < UserTest
@@ -26,21 +18,21 @@ class UserNameTest < UserTest
     assert_not @user.valid?
   end
 
-  # test "nameの長さが長すぎるとuserがinvalidになる" do
-  #   @user.username = "a" * 5111
-  #   assert_not @user.valid?
-  # end
+  test "nameの長さが長すぎるとuserがinvalidになる" do
+    @user.username = "a" * 5111
+    assert_not @user.valid?
+  end
 
-  # test "既に存在する名前を保存すると、invalidになる" do
-  #   @user.save
-  #   @other_user = User.new(username: @user.username, email: "other@example.com", password: "foobar", password_confirmation: "foobar")
-  #   assert_not @other_user.valid?
-  # end
+  test "既に存在する名前を保存すると、invalidになる" do
+    @user.save
+    @other_user = User.new(username: @user.username, email: "other@example.com", password: "foobar", password_confirmation: "foobar")
+    assert_not @other_user.valid?
+  end
 
-  # test "usernameにドットが含まれると、invalidになる" do
-  #   @user.username = "Ex. User"
-  #   assert_not @user.valid?
-  # end
+  test "usernameにドットが含まれると、invalidになる" do
+    @user.username = "Ex. User"
+    assert_not @user.valid?
+  end
 end
 
 class UserEmailTest < UserTest
@@ -49,69 +41,97 @@ class UserEmailTest < UserTest
     assert_not @user.valid?
   end
 
-  # test "emailの長さが長すぎると、userがinvalidになる" do
-  #   @user.email = "a" * 244 + "@example.com"
-  #   assert_not @user.valid?
-  # end
+  test "emailの長さが長すぎると、userがinvalidになる" do
+    @user.email = "a" * 244 + "@example.com"
+    assert_not @user.valid?
+  end
 
-  # test "emailのフォーマットが間違っていると、userがinvalidになる" do
-  #   invalid_addresses = %w[user@example,com # ドットの代わりにカンマを使用
-  #                          user_at_foo.org # アットマークがない
-  #                          user.name@example.foo@bar_baz.com # アットマークが2つ
-  #                          foo@bar+baz.com # ドメイン名にプラスが入っている
-  #                          user@example..com # ドットが2つ連続している
-  #                          ]
+  test "emailのフォーマットが間違っていると、userがinvalidになる" do
+    invalid_addresses = %w[user@example,com # ドットの代わりにカンマを使用
+                           user_at_foo.org # アットマークがない
+                           user.name@example.foo@bar_baz.com # アットマークが2つ
+                           foo@bar+baz.com # ドメイン名にプラスが入っている
+                           user@example..com # ドットが2つ連続している
+                           ]
 
-  #   invalid_addresses.each do |invalid_address|
-  #     @user.email = invalid_address
-  #     assert_not @user.valid?, "#{invalid_address.inspect}のフォーマットエラーを検知できていません。"
-  #   end
-  # end
+    invalid_addresses.each do |invalid_address|
+      @user.email = invalid_address
+      assert_not @user.valid?, "#{invalid_address.inspect}のフォーマットエラーを検知できていません。"
+    end
+  end
 
-  # test "同じemailが存在すると、userはinvalidになる" do
-  #   duplicate_user = @user.dup
-  #   @user.save
-  #   assert_not duplicate_user.valid?
-  # end
+  test "同じemailが存在すると、userはinvalidになる" do
+    duplicate_user = @user.dup
+    @user.save
+    assert_not duplicate_user.valid?
+  end
 
-  # test "emailがlowercaseとして保存されているか" do
-  #   mixed_case_email = "Foo@ExamPLe.CoM"
-  #   @user.email = mixed_case_email
-  #   @user.save
-  #   assert_equal mixed_case_email.downcase, @user.reload.email
-  # end
+  test "emailがlowercaseとして保存されているか" do
+    mixed_case_email = "Foo@ExamPLe.CoM"
+    @user.email = mixed_case_email
+    @user.save
+    assert_equal mixed_case_email.downcase, @user.reload.email
+  end
 end
 
 class UserPasswordTest < UserTest
-  # test "passwordが存在しないと、userがinvalidになる" do
-  #   @user.password = " " * 6
-  #   assert_not @user.valid?
-  # end
+  test "passwordが存在しないと、userがinvalidになる" do
+    @user.password = " " * 6
+    assert_not @user.valid?
+  end
 
-  # test "passwordが短すぎると、userがinvalidになる" do
-  #   @user.password = "a" * 5
-  #   assert_not @user.valid?
-  # end
+  test "passwordが短すぎると、userがinvalidになる" do
+    @user.password = "a" * 5
+    assert_not @user.valid?
+  end
+end
+
+class UserArticleTest < UserTest
+  test "Userを削除するとArticleも削除される" do
+    @user.save
+    @user.articles.create!(description: "description", body: "Lorem ipsum", title: "title", slug: "title")
+    assert_difference "Article.count", -1 do
+      @user.destroy
+    end
+end
 end
 
 class UserfollowTest < UserTest
-  test "followとunfollowができる" do
-    sakana = users(:sakana)
-    fish = users(:fish)
+  def setup
+    super()
+    @sakana = users(:sakana)
+    @fish = users(:fish)
+  end
 
+  test "followとunfollowができる" do
     # follow
-    assert_not sakana.following?(fish)
-    sakana.follow(fish)
-    assert sakana.following?(fish)
-    assert fish.followers.include?(sakana)
+    assert_not @sakana.following?(@fish)
+    @sakana.follow(@fish)
+    assert @sakana.following?(@fish)
+    assert @fish.followers.include?(@sakana)
 
     # unfollow
-    sakana.unfollow(fish)
-    assert_not sakana.following?(fish)
+    @sakana.unfollow(@fish)
+    assert_not @sakana.following?(@fish)
     
     # ユーザーは自分自身をフォローできない
-    assert_not sakana.following?(sakana)
-    sakana.follow(sakana)
-    assert_not sakana.following?(sakana)
+    assert_not @sakana.following?(@sakana)
+    @sakana.follow(@sakana)
+    assert_not @sakana.following?(@sakana)
+  end
+
+  test "同じ人を2回followできない" do
+    @follow1 = Relationship.new(follower_id: @sakana.id, followed_id: @fish.id)
+    @follow1.save
+    @follow2 = Relationship.new(follower_id: @sakana.id, followed_id: @fish.id)
+    assert_not @follow2.valid?
+  end
+
+  test "Userを削除すると、Relationshipも削除される" do
+    @user.save
+    @user.follow(@sakana)
+    assert_difference "User.count", -1 do
+      @user.destroy
+    end
   end
 end


### PR DESCRIPTION
## 実施タスク
Userモデルのテスト fixes #68

## 実施内容
### テスト
- usernameのvalidation
- emailのvalidation
- passwordのvalidation
- followのテスト
- Userが削除されるとArticleも削除される

### それ以外の変更
- Relationshipのappのunique設定
- username, email, passwordのvalidationの追加

## その他 / 備考
なし