### PR TITLE
:+1: ArticleとCommentのAuthorの修正 fixes #98

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -7,14 +7,14 @@ class ArticlesController < ApplicationController
     common_filter(ids)
 
     render status: :ok, json: { 
-      articles: ActiveModel::Serializer::CollectionSerializer.new(@articles, serializer: ArticleSerializer, tagFilterName: params[:tag]), 
+      articles: ActiveModel::Serializer::CollectionSerializer.new(@articles, serializer: ArticleSerializer, tagFilterName: params[:tag], current_user: @current_user), 
       articlesCount: @articles.size
     }
   end
 
   def show
     @article = Article.find_by(slug: params[:slug])
-    render status: :ok, json: @article, serializer: ArticleSerializer, root: "article", adapter: :json
+    render status: :ok, json: @article, serializer: ArticleSerializer, root: "article", adapter: :json, current_user: @current_user
   end
 
   def create
@@ -23,7 +23,7 @@ class ArticlesController < ApplicationController
     @article.set_tags(params[:article][:tagList])
 
     if @article.save
-      render status: :created, json: @article, serializer: ArticleSerializer, root: "article", adapter: :json
+      render status: :created, json: @article, serializer: ArticleSerializer, root: "article", adapter: :json, current_user: @current_user
     else
       render status: :unprocessable_entity, json: @article.errors
     end
@@ -32,7 +32,7 @@ class ArticlesController < ApplicationController
   def update
     @article = Article.find_by(slug: params[:slug])
     if @article.update(article_params)
-      render status: :created, json: @article, serializer: ArticleSerializer, root: "article", adapter: :json
+      render status: :created, json: @article, serializer: ArticleSerializer, root: "article", adapter: :json, current_user: @current_user
     else
       render status: :unprocessable_entity, json: @article.errors
     end
@@ -62,7 +62,7 @@ class ArticlesController < ApplicationController
 
     common_filter(ids)
     render status: :ok, json: { 
-      articles: ActiveModel::Serializer::CollectionSerializer.new(@articles, serializer: ArticleSerializer), 
+      articles: ActiveModel::Serializer::CollectionSerializer.new(@articles, serializer: ArticleSerializer, current_user: @current_user), 
       articlesCount: @articles.size
     }
   end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -6,7 +6,7 @@ class CommentsController < ApplicationController
     @article = Article.find_by(slug: params[:slug])
     @comments = @article.comments
     render status: :ok, json: { 
-      comments: ActiveModel::Serializer::CollectionSerializer.new(@comments, serializer: CommentSerializer), 
+      comments: ActiveModel::Serializer::CollectionSerializer.new(@comments, serializer: CommentSerializer, current_user: @current_user), 
     }
   end
 
@@ -14,7 +14,7 @@ class CommentsController < ApplicationController
     @article = Article.find_by(slug: params[:slug])
     @comment = @article.comments.build(body: params[:comment][:body], user: @current_user)
     if @comment.save
-      render status: :created, json: @comment, serializer: CommentSerializer, root: "comment", adapter: :json
+      render status: :created, json: @comment, serializer: CommentSerializer, root: "comment", adapter: :json, current_user: @current_use
     else
       render status: :unprocessable_entity, json: @comment.errors
     end

--- a/app/serializers/article_serializer.rb
+++ b/app/serializers/article_serializer.rb
@@ -1,7 +1,7 @@
 class ArticleSerializer < ActiveModel::Serializer
   attributes %i[slug title description body tagList createdAt updatedAt favorited favoritesCount]
 
-  has_one :user, key: :author, serializer: AuthorSerializer
+  has_one :user, key: :author, serializer: ProfileSerializer, current_user: @current_user
 
   def initialize(object, options = {})
     super(object, options)

--- a/app/serializers/author_serializer.rb
+++ b/app/serializers/author_serializer.rb
@@ -1,3 +1,0 @@
-class AuthorSerializer < ActiveModel::Serializer
-  attributes %i[username bio image]
-end

--- a/app/serializers/comment_serializer.rb
+++ b/app/serializers/comment_serializer.rb
@@ -1,7 +1,12 @@
 class CommentSerializer < ActiveModel::Serializer
   attributes %i[id createdAt updatedAt body]
 
-  has_one :user, key: :author, serializer: AuthorSerializer
+  has_one :user, key: :author, serializer: ProfileSerializer, current_user: @current_user
+
+  def initialize(object, options = {})
+    super(object, options)
+    @current_user = options[:current_user]
+  end
 
   def createdAt
     object.created_at

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -15,4 +15,9 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     get comments_path(@article.slug), headers: header_token(@user)
     assert_response :ok
   end
+
+  test "コメントのauthorにfollowingが含まれている" do
+    get comments_path(@article.slug), headers: header_token(@user)
+    JSON.parse(response.body)["comments"][0]["author"].key?("following")
+  end
 end

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -7,3 +7,8 @@ blue:
   body: "This color is blue. "
   article: dragon
   user: fish
+
+green:
+  body: "This color is green. "
+  article: dragon
+  user: uo


### PR DESCRIPTION
## 実施タスク
ArticleとCommentのAuthorの修正 fixes #98

## 実施内容
- AuthorSerializerの削除
- 代わりにProfileSerializerを使用するように変更
- @current_userをCommentSerializerとArticleSerializerでもオプションとして受け取るように変更

## その他 / 備考
なし